### PR TITLE
Task1 try-catchでエラーハンドリング追加、エラー表示追加

### DIFF
--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
@@ -15,7 +15,7 @@ internal interface SpaceService {
         @Body body: GetAllThreadsBody,
     ): ThreadListResponse
 
-    @POST("k/api/space/thread/post/list.json")
+    @POST("k/api/space/thread/post/hoge.json") // list.json→hoge.json
     suspend fun getMessagesForThread(
         @Header("X-Cybozu-Authorization") encodeString: String,
         @Body body: GetMessagesForThreadBody,

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
@@ -15,7 +15,7 @@ internal interface SpaceService {
         @Body body: GetAllThreadsBody,
     ): ThreadListResponse
 
-    @POST("k/api/space/thread/post/list.json")
+    @POST("k/api/space/thread/post/lst.json")
     suspend fun getMessagesForThread(
         @Header("X-Cybozu-Authorization") encodeString: String,
         @Body body: GetMessagesForThreadBody,

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
@@ -15,7 +15,7 @@ internal interface SpaceService {
         @Body body: GetAllThreadsBody,
     ): ThreadListResponse
 
-    @POST("k/api/space/thread/post/hoge.json") // list.json→hoge.json
+    @POST("k/api/space/thread/post/list.json")
     suspend fun getMessagesForThread(
         @Header("X-Cybozu-Authorization") encodeString: String,
         @Body body: GetMessagesForThreadBody,

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -109,7 +110,10 @@ fun ThreadContent(
                     }
                 }
             } else { // 読み込めなければエラー表示
-                Toast.makeText(LocalContext.current, "メッセージを取得できませんでした", Toast.LENGTH_SHORT).show()
+                val context = LocalContext.current
+                LaunchedEffect(uiState.isError) {
+                    Toast.makeText(context, "メッセージを取得できませんでした", Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -222,7 +222,7 @@ class ThreadContentPreviewParameter :
                         )
                     ),
                 isLoading = false,
-                isError= false
+                isError = false
             ),
             ThreadUiState(
                 threadMessages = emptyList(),

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
@@ -108,11 +109,8 @@ fun ThreadContent(
                         MessageListItem(threadMessage = threadMessage)
                     }
                 }
-                Toast.makeText(LocalContext.current, "メッセージを取得", Toast.LENGTH_SHORT).show()
-            } else {
-                println("debug point 1")
+            } else { // 読み込めなければエラー表示
                 Toast.makeText(LocalContext.current, "メッセージを取得できませんでした", Toast.LENGTH_SHORT).show()
-                // Toastでメッセージ表示
             }
         }
     }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -1,5 +1,6 @@
 package com.cybozu.sample.kintone.spaces.feature.communicate.thread
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -92,17 +94,22 @@ fun ThreadContent(
                 CircularProgressIndicator()
             }
         } else {
-            LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
-                contentPadding = PaddingValues(all = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(uiState.threadMessages) { threadMessage ->
-                    MessageListItem(threadMessage = threadMessage)
+            if (uiState.isLoaded) { // 正常に読み込まれていればリスト表示
+                LazyColumn(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentPadding = PaddingValues(all = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.threadMessages) { threadMessage ->
+                        MessageListItem(threadMessage = threadMessage)
+                    }
                 }
+            } else {
+                Toast.makeText(LocalContext.current, "メッセージを取得できませんでした", Toast.LENGTH_SHORT).show()
+                // Toastでメッセージ表示
             }
         }
     }
@@ -210,11 +217,13 @@ class ThreadContentPreviewParameter :
                             comments = emptyList()
                         )
                     ),
-                isLoading = false
+                isLoading = false,
+                isLoaded = true
             ),
             ThreadUiState(
                 threadMessages = emptyList(),
-                isLoading = true
+                isLoading = true,
+                isLoaded = false
             )
         )
     )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -94,7 +94,7 @@ fun ThreadContent(
                 CircularProgressIndicator()
             }
         } else {
-            if (uiState.isLoaded) { // 正常に読み込まれていればリスト表示
+            if (!uiState.isError) { // 正常に読み込まれていればリスト表示
                 println("debug point")
                 LazyColumn(
                     modifier =
@@ -218,12 +218,12 @@ class ThreadContentPreviewParameter :
                         )
                     ),
                 isLoading = false,
-                isLoaded = true
+                isError= false
             ),
             ThreadUiState(
                 threadMessages = emptyList(),
                 isLoading = true,
-                isLoaded = false
+                isError = true
             )
         )
     )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -95,6 +95,7 @@ fun ThreadContent(
             }
         } else {
             if (uiState.isLoaded) { // 正常に読み込まれていればリスト表示
+                println("debug point")
                 LazyColumn(
                     modifier =
                         Modifier
@@ -107,7 +108,9 @@ fun ThreadContent(
                         MessageListItem(threadMessage = threadMessage)
                     }
                 }
+                Toast.makeText(LocalContext.current, "メッセージを取得", Toast.LENGTH_SHORT).show()
             } else {
+                println("debug point 1")
                 Toast.makeText(LocalContext.current, "メッセージを取得できませんでした", Toast.LENGTH_SHORT).show()
                 // Toastでメッセージ表示
             }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -5,5 +5,5 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 data class ThreadUiState(
     val threadMessages: List<ThreadMessage> = emptyList(),
     val isLoading: Boolean = false,
-    val isLoaded: Boolean = false, // Load Flag
+    val isError: Boolean = false, // Flag of Thread Message
 )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -5,4 +5,5 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 data class ThreadUiState(
     val threadMessages: List<ThreadMessage> = emptyList(),
     val isLoading: Boolean = false,
+    val isLoaded: Boolean = false, // Load Flag
 )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -26,7 +26,16 @@ class ThreadViewModel @AssistedInject constructor(
     val uiState: StateFlow<ThreadUiState> = _uiState.asStateFlow()
 
     init {
-        loadMessages()
+        try {
+            loadMessages() // メッセージのロード
+        } catch (_: Exception) {
+            _uiState.value =
+                _uiState.value.copy(
+                    threadMessages = emptyList(),
+                    isLoading = false,
+                    isLoaded = false // 失敗した場合、Load Flag をfalseに設定
+                )
+        }
     }
 
     private fun loadMessages() {
@@ -36,7 +45,8 @@ class ThreadViewModel @AssistedInject constructor(
             _uiState.value =
                 _uiState.value.copy(
                     threadMessages = threadMessages,
-                    isLoading = false
+                    isLoading = false,
+                    isLoaded = true // LoadFlag をtrueに設定
                 )
         }
     }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -7,7 +7,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.io.IOException
+import kotlin.coroutines.cancellation.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,7 +31,7 @@ class ThreadViewModel @AssistedInject constructor(
     }
 
     private fun loadMessages() {
-        viewModelScope.launch {
+        viewModelScope.launch { // launchの中がコルーチン: 非同期処理　Exceptionの形式には注意
             try {
                 _uiState.value = _uiState.value.copy(isLoading = true)
                 val threadMessages = repository.getMessagesForThread(threadId = threadId)
@@ -41,7 +41,10 @@ class ThreadViewModel @AssistedInject constructor(
                         isLoading = false,
                         isError = false // isError: falseに設定
                     )
-            } catch (_: IOException) {
+            } catch (e: CancellationException){
+                throw e // Catch & Release CancellationException
+
+            } catch (_: Exception) {
                 _uiState.value =
                     _uiState.value.copy(
                         threadMessages = emptyList(),

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -31,7 +31,8 @@ class ThreadViewModel @AssistedInject constructor(
     }
 
     private fun loadMessages() {
-        viewModelScope.launch { // launchの中がコルーチン: 非同期処理　Exceptionの形式には注意
+        viewModelScope.launch {
+            // launchの中がコルーチン: 非同期処理　Exceptionの形式には注意
             try {
                 _uiState.value = _uiState.value.copy(isLoading = true)
                 val threadMessages = repository.getMessagesForThread(threadId = threadId)
@@ -41,9 +42,8 @@ class ThreadViewModel @AssistedInject constructor(
                         isLoading = false,
                         isError = false // isError: falseに設定
                     )
-            } catch (e: CancellationException){
+            } catch (e: CancellationException) {
                 throw e // Catch & Release CancellationException
-
             } catch (_: Exception) {
                 _uiState.value =
                     _uiState.value.copy(

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -7,6 +7,7 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.io.IOException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -40,7 +41,7 @@ class ThreadViewModel @AssistedInject constructor(
                         isLoading = false,
                         isError = false // isError: falseに設定
                     )
-            } catch (_: Exception) {
+            } catch (_: IOException) {
                 _uiState.value =
                     _uiState.value.copy(
                         threadMessages = emptyList(),

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -26,28 +26,28 @@ class ThreadViewModel @AssistedInject constructor(
     val uiState: StateFlow<ThreadUiState> = _uiState.asStateFlow()
 
     init {
-        try {
-            loadMessages() // メッセージのロード
-        } catch (_: Exception) {
-            _uiState.value =
-                _uiState.value.copy(
-                    threadMessages = emptyList(),
-                    isLoading = false,
-                    isLoaded = false // 失敗した場合、Load Flag をfalseに設定
-                )
-        }
+        loadMessages() // メッセージのロード
     }
 
     private fun loadMessages() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
-            val threadMessages = repository.getMessagesForThread(threadId = threadId)
-            _uiState.value =
-                _uiState.value.copy(
-                    threadMessages = threadMessages,
-                    isLoading = false,
-                    isLoaded = true // LoadFlag をtrueに設定
-                )
+            try {
+                _uiState.value = _uiState.value.copy(isLoading = true)
+                val threadMessages = repository.getMessagesForThread(threadId = threadId)
+                _uiState.value =
+                    _uiState.value.copy(
+                        threadMessages = threadMessages,
+                        isLoading = false,
+                        isLoaded = true // LoadFlag をtrueに設定
+                    )
+            } catch (_: Exception) {
+                _uiState.value =
+                    _uiState.value.copy(
+                        threadMessages = emptyList(),
+                        isLoading = false,
+                        isLoaded = false // 失敗した場合、Load Flag をfalseに設定
+                    )
+            }
         }
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -38,14 +38,14 @@ class ThreadViewModel @AssistedInject constructor(
                     _uiState.value.copy(
                         threadMessages = threadMessages,
                         isLoading = false,
-                        isLoaded = true // LoadFlag をtrueに設定
+                        isError = false // isError: falseに設定
                     )
             } catch (_: Exception) {
                 _uiState.value =
                     _uiState.value.copy(
                         threadMessages = emptyList(),
                         isLoading = false,
-                        isLoaded = false // 失敗した場合、Load Flag をfalseに設定
+                        isError = true // 失敗した場合、isError: trueに設定
                     )
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.0"
+agp = "8.11.1"
 hiltNavigationCompose = "1.2.0"
 kotestAssertionsCore = "5.9.1"
 kotlin = "2.2.0"


### PR DESCRIPTION
方針：一旦機能するモノを作る。
個人的にtry-catchの扱いに慣れていたため、一旦try-catch方針で。

- issue1 状態 : ThreadUIState.ktに、正常にスレッドを読み込めたかどうかを示すBoolean isLoadedを追加
- issue2 Model: isLoaded()関数を　try-catchブロックで囲んだ。エラーの場合、isLoaded=false
- issue3 UI : isLoaded=falseの場合、Toastを表示
- issue4 トーストが出ない: 動作確認の手順を誤っていた。正常に動作。