### PR TITLE
Grfsv/task1 通信エラー発生時のメッセージ表示を追加

### DIFF
--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRemoteDataSource.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRemoteDataSource.kt
@@ -1,6 +1,5 @@
 package com.cybozu.sample.kintone.spaces.data.space
 
-import android.util.Log
 import com.cybozu.sample.kintone.spaces.data.space.entity.GetAllThreadsBody
 import com.cybozu.sample.kintone.spaces.data.space.entity.GetMessagesForThreadBody
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadListResponse
@@ -9,6 +8,7 @@ import javax.inject.Inject
 import kotlin.Result.Companion.failure
 import kotlin.Result.Companion.success
 import okio.ByteString.Companion.encode
+import okio.IOException
 import retrofit2.Retrofit
 
 internal class SpaceRemoteDataSource @Inject constructor(
@@ -23,17 +23,15 @@ internal class SpaceRemoteDataSource @Inject constructor(
             body = GetAllThreadsBody(spaceId = spaceId)
         )
 
-    suspend fun getMessagesForThread(threadId: String): Result<ThreadMessageResponse> {
+    suspend fun getMessagesForThread(threadId: String): Result<ThreadMessageResponse> =
         try {
-            return success(
+            success(
                 spaceService.getMessagesForThread(
                     encodeString = usernamePassword.encode().base64(),
                     body = GetMessagesForThreadBody(threadId = threadId)
                 )
             )
-        } catch (e: Exception) {
-            Log.d("TAG", e.toString())
-            return failure(e)
+        } catch (e: IOException) {
+            failure(e)
         }
-    }
 }

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRemoteDataSource.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRemoteDataSource.kt
@@ -1,10 +1,13 @@
 package com.cybozu.sample.kintone.spaces.data.space
 
+import android.util.Log
 import com.cybozu.sample.kintone.spaces.data.space.entity.GetAllThreadsBody
 import com.cybozu.sample.kintone.spaces.data.space.entity.GetMessagesForThreadBody
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadListResponse
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessageResponse
 import javax.inject.Inject
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
 import okio.ByteString.Companion.encode
 import retrofit2.Retrofit
 
@@ -20,9 +23,17 @@ internal class SpaceRemoteDataSource @Inject constructor(
             body = GetAllThreadsBody(spaceId = spaceId)
         )
 
-    suspend fun getMessagesForThread(threadId: String): ThreadMessageResponse =
-        spaceService.getMessagesForThread(
-            encodeString = usernamePassword.encode().base64(),
-            body = GetMessagesForThreadBody(threadId = threadId)
-        )
+    suspend fun getMessagesForThread(threadId: String): Result<ThreadMessageResponse> {
+        try {
+            return success(
+                spaceService.getMessagesForThread(
+                    encodeString = usernamePassword.encode().base64(),
+                    body = GetMessagesForThreadBody(threadId = threadId)
+                )
+            )
+        } catch (e: Exception) {
+            Log.d("TAG", e.toString())
+            return failure(e)
+        }
+    }
 }

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepository.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepository.kt
@@ -6,5 +6,5 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 interface SpaceRepository {
     suspend fun getAllThreads(spaceId: String): List<Thread>
 
-    suspend fun getMessagesForThread(threadId: String): List<ThreadMessage>
+    suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>>
 }

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepositoryImpl.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepositoryImpl.kt
@@ -9,6 +9,8 @@ internal class SpaceRepositoryImpl @Inject constructor(
 ) : SpaceRepository {
     override suspend fun getAllThreads(spaceId: String): List<Thread> = spaceRemoteDataSource.getAllThreads(spaceId = spaceId).result.items
 
-    override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> =
-        spaceRemoteDataSource.getMessagesForThread(threadId = threadId).result.items
+    override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> =
+        spaceRemoteDataSource
+            .getMessagesForThread(threadId = threadId)
+            .map { it.result.items }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -1,5 +1,6 @@
 package com.cybozu.sample.kintone.spaces.feature.communicate.thread
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,6 +32,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -43,6 +46,7 @@ import com.cybozu.sample.kintone.spaces.core.design.theme.KintoneSpacesTheme
 import com.cybozu.sample.kintone.spaces.data.space.entity.Comment
 import com.cybozu.sample.kintone.spaces.data.space.entity.Creator
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
+import com.cybozu.sample.kintone.spaces.feature.communicate.R
 
 @Composable
 fun ThreadScreen(
@@ -69,6 +73,7 @@ fun ThreadContent(
     threadName: String,
     uiState: ThreadUiState,
 ) {
+    val context = LocalContext.current
     Scaffold(
         topBar = {
             TopAppBar(
@@ -81,27 +86,34 @@ fun ThreadContent(
             )
         }
     ) { innerPadding ->
-        if (uiState.isLoading) {
-            Box(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator()
+        when (uiState) {
+            is ThreadUiState.Idle -> {}
+            is ThreadUiState.Error -> {
+                Toast.makeText(context, stringResource(uiState.messageId), Toast.LENGTH_SHORT).show()
             }
-        } else {
-            LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
-                contentPadding = PaddingValues(all = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
-            ) {
-                items(uiState.threadMessages) { threadMessage ->
-                    MessageListItem(threadMessage = threadMessage)
+            is ThreadUiState.Loading -> {
+                Box(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+            is ThreadUiState.Success -> {
+                LazyColumn(
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(innerPadding),
+                    contentPadding = PaddingValues(all = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.threadMessages) { threadMessage ->
+                        MessageListItem(threadMessage = threadMessage)
+                    }
                 }
             }
         }
@@ -170,7 +182,7 @@ private fun MessageCard(
 class ThreadContentPreviewParameter :
     CollectionPreviewParameterProvider<ThreadUiState>(
         listOf(
-            ThreadUiState(
+            ThreadUiState.Success(
                 threadMessages =
                     listOf(
                         ThreadMessage(
@@ -209,12 +221,11 @@ class ThreadContentPreviewParameter :
                             creator = Creator(name = "name2"),
                             comments = emptyList()
                         )
-                    ),
-                isLoading = false
+                    )
             ),
-            ThreadUiState(
-                threadMessages = emptyList(),
-                isLoading = true
+            ThreadUiState.Loading,
+            ThreadUiState.Error(
+                messageId = R.string.thread_error
             )
         )
     )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -1,8 +1,18 @@
 package com.cybozu.sample.kintone.spaces.feature.communicate.thread
 
+import androidx.annotation.StringRes
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 
-data class ThreadUiState(
-    val threadMessages: List<ThreadMessage> = emptyList(),
-    val isLoading: Boolean = false,
-)
+sealed class ThreadUiState {
+    object Idle : ThreadUiState()
+
+    object Loading : ThreadUiState()
+
+    data class Error(
+        @param:StringRes val messageId: Int,
+    ) : ThreadUiState()
+
+    data class Success(
+        val threadMessages: List<ThreadMessage>,
+    ) : ThreadUiState()
+}

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -3,6 +3,7 @@ package com.cybozu.sample.kintone.spaces.feature.communicate.thread
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cybozu.sample.kintone.spaces.data.space.SpaceRepository
+import com.cybozu.sample.kintone.spaces.feature.communicate.R
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -22,7 +23,7 @@ class ThreadViewModel @AssistedInject constructor(
     @Assisted private val threadId: String,
     private val repository: SpaceRepository,
 ) : ViewModel() {
-    private val _uiState = MutableStateFlow(ThreadUiState())
+    private val _uiState = MutableStateFlow<ThreadUiState>(ThreadUiState.Idle)
     val uiState: StateFlow<ThreadUiState> = _uiState.asStateFlow()
 
     init {
@@ -31,13 +32,20 @@ class ThreadViewModel @AssistedInject constructor(
 
     private fun loadMessages() {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
-            val threadMessages = repository.getMessagesForThread(threadId = threadId)
-            _uiState.value =
-                _uiState.value.copy(
-                    threadMessages = threadMessages,
-                    isLoading = false
-                )
+            _uiState.value = ThreadUiState.Loading
+            val result = repository.getMessagesForThread(threadId = threadId)
+
+            result.getOrNull()?.let {
+                _uiState.value =
+                    ThreadUiState.Success(
+                        threadMessages = it
+                    )
+            } ?: run {
+                _uiState.value =
+                    ThreadUiState.Error(
+                        messageId = R.string.thread_error
+                    )
+            }
         }
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -35,17 +35,18 @@ class ThreadViewModel @AssistedInject constructor(
             _uiState.value = ThreadUiState.Loading
             val result = repository.getMessagesForThread(threadId = threadId)
 
-            result.getOrNull()?.let {
-                _uiState.value =
-                    ThreadUiState.Success(
-                        threadMessages = it
-                    )
-            } ?: run {
-                _uiState.value =
-                    ThreadUiState.Error(
-                        messageId = R.string.thread_error
-                    )
-            }
+            result
+                .onSuccess {
+                    _uiState.value =
+                        ThreadUiState.Success(
+                            threadMessages = it
+                        )
+                }.onFailure {
+                    _uiState.value =
+                        ThreadUiState.Error(
+                            messageId = R.string.thread_error
+                        )
+                }
         }
     }
 }

--- a/feature/communicate/src/main/res/values/strings.xml
+++ b/feature/communicate/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="thread_error">メッセージを取得できませんでした</string>
+</resources>

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceViewModelTest.kt
@@ -4,9 +4,7 @@ import app.cash.turbine.test
 import com.cybozu.sample.kintone.spaces.data.space.SpaceRepository
 import com.cybozu.sample.kintone.spaces.data.space.entity.Thread
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
-import com.cybozu.sample.kintone.spaces.feature.communicate.thread.ThreadUiState
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.types.instanceOf
 import kotlin.Result.Companion.success
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -44,18 +42,14 @@ class SpaceViewModelTest {
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
-                initialState shouldBe instanceOf<ThreadUiState.Idle>()
-//                initialState.threads shouldBe emptyList()
-//                initialState.isLoading shouldBe false
+                initialState.threads shouldBe emptyList()
+                initialState.isLoading shouldBe false
 
                 val loadingState = awaitItem()
-                loadingState shouldBe instanceOf<ThreadUiState.Loading>()
-//                loadingState.threads shouldBe emptyList()
-//                loadingState.isLoading shouldBe true
+                loadingState.threads shouldBe emptyList()
+                loadingState.isLoading shouldBe true
 
                 val loadedState = awaitItem()
-                loadedState shouldBe instanceOf<ThreadUiState.Success>()
-
                 loadedState.threads.size shouldBe 2
                 loadedState.threads[0].id shouldBe "thread-1"
                 loadedState.threads[0].name shouldBe "Test Thread 1"

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceViewModelTest.kt
@@ -4,7 +4,10 @@ import app.cash.turbine.test
 import com.cybozu.sample.kintone.spaces.data.space.SpaceRepository
 import com.cybozu.sample.kintone.spaces.data.space.entity.Thread
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
+import com.cybozu.sample.kintone.spaces.feature.communicate.thread.ThreadUiState
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.instanceOf
+import kotlin.Result.Companion.success
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
@@ -41,14 +44,18 @@ class SpaceViewModelTest {
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
-                initialState.threads shouldBe emptyList()
-                initialState.isLoading shouldBe false
+                initialState shouldBe instanceOf<ThreadUiState.Idle>()
+//                initialState.threads shouldBe emptyList()
+//                initialState.isLoading shouldBe false
 
                 val loadingState = awaitItem()
-                loadingState.threads shouldBe emptyList()
-                loadingState.isLoading shouldBe true
+                loadingState shouldBe instanceOf<ThreadUiState.Loading>()
+//                loadingState.threads shouldBe emptyList()
+//                loadingState.isLoading shouldBe true
 
                 val loadedState = awaitItem()
+                loadedState shouldBe instanceOf<ThreadUiState.Success>()
+
                 loadedState.threads.size shouldBe 2
                 loadedState.threads[0].id shouldBe "thread-1"
                 loadedState.threads[0].name shouldBe "Test Thread 1"
@@ -68,5 +75,5 @@ private class FakeSpaceRepository : SpaceRepository {
         )
     }
 
-    override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> = emptyList()
+    override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> = success(emptyList())
 }

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -6,6 +6,10 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.Creator
 import com.cybozu.sample.kintone.spaces.data.space.entity.Thread
 import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.instanceOf
+import io.kotest.matchers.types.shouldBeInstanceOf
+import kotlin.Result.Companion.failure
+import kotlin.Result.Companion.success
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -41,22 +45,21 @@ class ThreadViewModelTest {
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
-                initialState.threadMessages shouldBe emptyList()
-                initialState.isLoading shouldBe false
+                initialState shouldBe instanceOf<ThreadUiState.Idle>()
 
                 val loadingState = awaitItem()
-                loadingState.threadMessages shouldBe emptyList()
-                loadingState.isLoading shouldBe true
+                loadingState shouldBe instanceOf<ThreadUiState.Loading>()
 
                 val loadedState = awaitItem()
-                loadedState.threadMessages.size shouldBe 2
-                loadedState.threadMessages[0].id shouldBe "msg-1"
-                loadedState.threadMessages[0].body shouldBe "thread-1"
-                loadedState.threadMessages[0].creator shouldBe Creator(name = "name1")
-                loadedState.threadMessages[1].id shouldBe "msg-2"
-                loadedState.threadMessages[1].body shouldBe "thread-2"
-                loadedState.threadMessages[1].creator shouldBe Creator(name = "name2")
-                loadedState.isLoading shouldBe false
+                loadedState.shouldBeInstanceOf<ThreadUiState.Success> {
+                    it.threadMessages.size shouldBe 2
+                    it.threadMessages[0].id shouldBe "msg-1"
+                    it.threadMessages[0].body shouldBe "thread-1"
+                    it.threadMessages[0].creator shouldBe Creator(name = "name1")
+                    it.threadMessages[1].id shouldBe "msg-2"
+                    it.threadMessages[1].body shouldBe "thread-2"
+                    it.threadMessages[1].creator shouldBe Creator(name = "name2")
+                }
             }
         }
 }
@@ -64,23 +67,25 @@ class ThreadViewModelTest {
 private class FakeSpaceRepository : SpaceRepository {
     override suspend fun getAllThreads(spaceId: String): List<Thread> = emptyList()
 
-    override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> {
+    override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> {
         if (threadId == "thread-1") {
-            return listOf(
-                ThreadMessage(
-                    id = "msg-1",
-                    body = "thread-1",
-                    creator = Creator(name = "name1"),
-                    comments = emptyList()
-                ),
-                ThreadMessage(
-                    id = "msg-2",
-                    body = "thread-2",
-                    creator = Creator(name = "name2"),
-                    comments = emptyList()
+            return success(
+                listOf(
+                    ThreadMessage(
+                        id = "msg-1",
+                        body = "thread-1",
+                        creator = Creator(name = "name1"),
+                        comments = emptyList()
+                    ),
+                    ThreadMessage(
+                        id = "msg-2",
+                        body = "thread-2",
+                        creator = Creator(name = "name2"),
+                        comments = emptyList()
+                    )
                 )
             )
         }
-        return emptyList()
+        return failure(RuntimeException())
     }
 }


### PR DESCRIPTION
## 主な変更点
### 通信失敗発生時にエラーメッセージを表示する処理を追加
Toastを利用して、通信失敗時にエラー内容を表示

### 通信の例外処理をtry-catchからResult型でハンドリングするように変更
DataSource内の処理でエラーハンドリングを行いResult型で例外を保持するように変更

### UiStateにサブクラスを追加し、状態ごとに必要な値だけを持つように変更
UiStateはsealed classで定義し、サブクラスによって状態を保持
下記の4つのサブクラスに分割
1. Idle（初期状態）
2. Loding（通信中）
3. Success（成功時）
4. Error（失敗時）


