### PR TITLE
feat: スレッドのメッセージ表示失敗時のエラー表示処理を実装

### DIFF
--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepository.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepository.kt
@@ -5,6 +5,5 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 
 interface SpaceRepository {
     suspend fun getAllThreads(spaceId: String): List<Thread>
-
-    suspend fun getMessagesForThread(threadId: String): List<ThreadMessage>
+    suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>>
 }

--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepositoryImpl.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceRepositoryImpl.kt
@@ -7,8 +7,11 @@ import javax.inject.Inject
 internal class SpaceRepositoryImpl @Inject constructor(
     private val spaceRemoteDataSource: SpaceRemoteDataSource,
 ) : SpaceRepository {
-    override suspend fun getAllThreads(spaceId: String): List<Thread> = spaceRemoteDataSource.getAllThreads(spaceId = spaceId).result.items
+    override suspend fun getAllThreads(spaceId: String): List<Thread> =
+        spaceRemoteDataSource.getAllThreads(spaceId = spaceId).result.items
 
-    override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> =
-        spaceRemoteDataSource.getMessagesForThread(threadId = threadId).result.items
+        override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> =
+        runCatching {
+            spaceRemoteDataSource.getMessagesForThread(threadId = threadId).result.items
+        }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -23,11 +23,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -59,7 +63,8 @@ fun ThreadScreen(
 
     ThreadContent(
         threadName = threadName,
-        uiState = uiState
+        uiState = uiState,
+        onErrorMessageShown = viewModel::errorMessageShown
     )
 }
 
@@ -68,7 +73,9 @@ fun ThreadScreen(
 fun ThreadContent(
     threadName: String,
     uiState: ThreadUiState,
+    onErrorMessageShown: () -> Unit,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
         topBar = {
             TopAppBar(
@@ -79,6 +86,9 @@ fun ThreadContent(
                     SystemBackNavButton()
                 }
             )
+        },
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState)
         }
     ) { innerPadding ->
         if (uiState.isLoading) {
@@ -104,6 +114,13 @@ fun ThreadContent(
                     MessageListItem(threadMessage = threadMessage)
                 }
             }
+        }
+    }
+
+    uiState.errorMessage?.let { errorMessage ->
+        LaunchedEffect(errorMessage) {
+            snackbarHostState.showSnackbar(message = errorMessage)
+            onErrorMessageShown()
         }
     }
 }
@@ -227,7 +244,8 @@ fun ThreadContentPreview(
     KintoneSpacesTheme {
         ThreadContent(
             threadName = "Sample Thread",
-            uiState = uiState
+            uiState = uiState,
+            onErrorMessageShown = {}
         )
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -5,4 +5,7 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 data class ThreadUiState(
     val threadMessages: List<ThreadMessage> = emptyList(),
     val isLoading: Boolean = false,
+    val errorMessage: String? = null,//エラーメッセージを文字列で直接管理する。
+    //Booleanで管理することも最初考慮したが、エラーにも「サーバーエラー」や「ネットワークエラー」
+    // など様々なエラーが発生しうると考え、Stringでの管理を採用した。
 )

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -29,15 +29,37 @@ class ThreadViewModel @AssistedInject constructor(
         loadMessages()
     }
 
+    fun errorMessageShown() {
+        _uiState.value = _uiState.value.copy(errorMessage = null)
+    }
+
     private fun loadMessages() {
         viewModelScope.launch {
             _uiState.value = _uiState.value.copy(isLoading = true)
-            val threadMessages = repository.getMessagesForThread(threadId = threadId)
-            _uiState.value =
-                _uiState.value.copy(
-                    threadMessages = threadMessages,
-                    isLoading = false
-                )
+            repository.getMessagesForThread(threadId = threadId)
+                .onSuccess { threadMessages ->
+                    _uiState.value =
+                        _uiState.value.copy(
+                            threadMessages = threadMessages,
+                            isLoading = false
+                        )
+                }
+                .onFailure { // 'it' is the Throwable (error) here
+                    _uiState.value =
+                        _uiState.value.copy(
+                            isLoading = false,
+                            errorMessage = "メッセージを取得できませんでした\n原因: ${getLocalizedErrorMessage(it)}"
+                        )
+                }
+        }
+    }
+
+    private fun getLocalizedErrorMessage(throwable: Throwable): String {
+        return when (throwable) {
+            is java.net.UnknownHostException -> "サーバーが見つかりません"
+            is java.net.SocketTimeoutException -> "通信がタイムアウトしました"
+            is java.io.IOException -> "ネットワークエラーが発生しました"
+            else -> "不明なエラー"
         }
     }
 }


### PR DESCRIPTION
# エラーハンドリング機能の実装

## 概要
スレッド画面でのメッセージ取得失敗時に発生していたアプリクラッシュとエラー通知不備を解決しました。

## 課題
- メッセージ取得失敗時にアプリがクラッシュ
- エラー内容がユーザーに伝わらない
- 通信エラーなどによるクラッシュがユーザー体験上良くない。

## 実装内容

### 1. データ取得処理の安全化
- `Result`型ベースのエラーハンドリングを導入
- 通信失敗時も安全に結果を返却する仕組みを構築

### 2. ユーザー向けエラー通知

[要件]
- ViewModelでエラー検知機能を実装
- Snackbarによる「メッセージを取得できませんでした」の表示

[要件ではないが工夫したこと]
- エラー原因を日本語を表示を行い、ユーザビリティを向上。
- ユーザーはメッセージ取得できなかったことだけでなく、原因も知りたいだろうと考えた。

## 技術的選択の理由

### Snackbar採用理由
要件ヒント「ユーザーの操作を妨げないこと」を重視し、以下の理由でSnackbarを選択：
- 数秒後の自動消失
- Dialogと比較してユーザー操作の継続性を保持
- 最初に読んだ記事を見て、https://developer.android.com/develop/ui/compose/components/snackbar?hl=ja
snackbarを使いましたが、今回のようなエラー表示のような簡潔なものならtoast でも良かった気がしてきました。再試行ボタンとか今回入れる余地はなさそうなので。


## 動作検証手順
1. kintone spaceをスレッド表示可能な通信環境で起動
2. アプリを落とさずに、上部バーなどでWi-Fi/5G接続を無効化
3. 任意のスレッドを選択
4. 「メッセージを表示できませんでした」の表示を確認
<img width="273" height="575" alt="Screenshot 2025-08-19 at 12 28 00" src="https://github.com/user-attachments/assets/bf2aff67-fe5e-498c-8b0a-722769af36c2" />


## 期待される効果
- アプリクラッシュの根絶
- エラー発生時のユーザー体験向上