### PR TITLE
v-tnta/task2 ユニットテストの実装

### DIFF
--- a/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
+++ b/data/space/src/main/java/com/cybozu/sample/kintone/spaces/data/space/SpaceService.kt
@@ -15,7 +15,7 @@ internal interface SpaceService {
         @Body body: GetAllThreadsBody,
     ): ThreadListResponse
 
-    @POST("k/api/space/thread/post/lst.json")
+    @POST("k/api/space/thread/post/list.json")
     suspend fun getMessagesForThread(
         @Header("X-Cybozu-Authorization") encodeString: String,
         @Body body: GetMessagesForThreadBody,

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -29,9 +29,8 @@ class ThreadViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(repository: SpaceRepository): ThreadViewModel {
-        return ThreadViewModel(threadId = "thread-1", repository = repository)
-    }
+    private fun createViewModel(repository: SpaceRepository): ThreadViewModel =
+        ThreadViewModel(threadId = "thread-1", repository = repository)
 
     @Test
     fun `メッセージ一覧が取得できる`() =
@@ -112,6 +111,7 @@ private class FakeSpaceRepository : SpaceRepository {
 
 private class FakeSpaceRepositoryNoThreadMsg : SpaceRepository {
     override suspend fun getAllThreads(spaceId: String): List<Thread> = emptyList()
+
     override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> = throw Exception()
     // 厳密な挙動を再現する。ViewModel側のExceptionにcatchされるために、単なるEmptyListではなくExceptionをthrowする
 }

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -29,24 +29,25 @@ class ThreadViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(): ThreadViewModel {
-        val repository = FakeSpaceRepository()
+    private fun createViewModel(repository: SpaceRepository): ThreadViewModel {
         return ThreadViewModel(threadId = "thread-1", repository = repository)
     }
 
     @Test
     fun `メッセージ一覧が取得できる`() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel = createViewModel(FakeSpaceRepository())
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
                 initialState.threadMessages shouldBe emptyList()
                 initialState.isLoading shouldBe false
+                initialState.isError shouldBe false
 
                 val loadingState = awaitItem()
                 loadingState.threadMessages shouldBe emptyList()
                 loadingState.isLoading shouldBe true
+                loadingState.isError shouldBe false
 
                 val loadedState = awaitItem()
                 loadedState.threadMessages.size shouldBe 2
@@ -57,6 +58,30 @@ class ThreadViewModelTest {
                 loadedState.threadMessages[1].body shouldBe "thread-2"
                 loadedState.threadMessages[1].creator shouldBe Creator(name = "name2")
                 loadedState.isLoading shouldBe false
+                loadedState.isError shouldBe false
+            }
+        }
+
+    @Test
+    fun `メッセージ一覧が取得できない`() =
+        runTest {
+            val viewModel = createViewModel(FakeSpaceRepositoryNoThreadMsg())
+
+            viewModel.uiState.test {
+                val initialState = awaitItem()
+                initialState.threadMessages shouldBe emptyList()
+                initialState.isLoading shouldBe false
+                initialState.isError shouldBe false
+
+                val loadingState = awaitItem()
+                loadingState.threadMessages shouldBe emptyList()
+                loadingState.isLoading shouldBe true
+                loadingState.isError shouldBe false
+
+                val loadedState = awaitItem()
+                loadedState.threadMessages shouldBe emptyList()
+                loadedState.isLoading shouldBe false
+                loadedState.isError shouldBe true
             }
         }
 }
@@ -83,4 +108,10 @@ private class FakeSpaceRepository : SpaceRepository {
         }
         return emptyList()
     }
+}
+
+private class FakeSpaceRepositoryNoThreadMsg : SpaceRepository {
+    override suspend fun getAllThreads(spaceId: String): List<Thread> = emptyList()
+    override suspend fun getMessagesForThread(threadId: String): List<ThreadMessage> = throw Exception()
+    // 厳密な挙動を再現する。ViewModel側のExceptionにcatchされるために、単なるEmptyListではなくExceptionをthrowする
 }


### PR DESCRIPTION
ポイント
- Space Repositoryを継承した新たなクラス FakeSpaceRepositoryNoMsgを追加
- ↑ここではgetMessageForThread()にてExceptionをthrowするように変更
- createViewModel()の引数にSpaceRepositoryを追加