### PR TITLE
Grfsv/task3 PullToRefreshの動作を追加

### DIFF
--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -26,6 +26,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -63,7 +65,8 @@ fun ThreadScreen(
 
     ThreadContent(
         threadName = threadName,
-        uiState = uiState
+        uiState = uiState,
+        onRefresh = viewModel::refreshMessages
     )
 }
 
@@ -72,8 +75,11 @@ fun ThreadScreen(
 fun ThreadContent(
     threadName: String,
     uiState: ThreadUiState,
+    onRefresh: () -> Unit,
 ) {
     val context = LocalContext.current
+    val pullToRefreshState = rememberPullToRefreshState()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -86,36 +92,61 @@ fun ThreadContent(
             )
         }
     ) { innerPadding ->
-        when (uiState) {
-            is ThreadUiState.Idle -> {}
-            is ThreadUiState.Error -> {
-                Toast.makeText(context, stringResource(uiState.messageId), Toast.LENGTH_SHORT).show()
-            }
-            is ThreadUiState.Loading -> {
-                Box(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                    contentAlignment = Alignment.Center
-                ) {
-                    CircularProgressIndicator()
+        val isRefreshing = uiState is ThreadUiState.Refreshing
+        PullToRefreshBox(
+            isRefreshing = isRefreshing,
+            onRefresh = onRefresh,
+            state = pullToRefreshState,
+            modifier = Modifier.padding(innerPadding)
+        ) {
+            when (uiState) {
+                is ThreadUiState.Idle -> {}
+                is ThreadUiState.Error -> {
+                    Toast.makeText(context, stringResource(uiState.messageId), Toast.LENGTH_SHORT).show()
                 }
-            }
-            is ThreadUiState.Success -> {
-                LazyColumn(
-                    modifier =
-                        Modifier
-                            .fillMaxSize()
-                            .padding(innerPadding),
-                    contentPadding = PaddingValues(all = 16.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
-                ) {
-                    items(uiState.threadMessages) { threadMessage ->
-                        MessageListItem(threadMessage = threadMessage)
+                is ThreadUiState.Loading -> {
+                    Box(
+                        modifier =
+                            Modifier
+                                .fillMaxSize(),
+                        contentAlignment = Alignment.Center
+                    ) {
+                        CircularProgressIndicator()
                     }
                 }
+                is ThreadUiState.Success -> {
+                    MessageList(
+                        threadMessages = uiState.threadMessages,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                    )
+                }
+                is ThreadUiState.Refreshing -> {
+                    MessageList(
+                        threadMessages = uiState.threadMessages,
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                    )
+                }
             }
+        }
+    }
+}
+
+@Composable
+private fun MessageList(
+    threadMessages: List<ThreadMessage>,
+    modifier: Modifier,
+) {
+    LazyColumn(
+        modifier = modifier,
+        contentPadding = PaddingValues(all = 16.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        items(threadMessages) { threadMessage ->
+            MessageListItem(threadMessage = threadMessage)
         }
     }
 }
@@ -238,7 +269,8 @@ fun ThreadContentPreview(
     KintoneSpacesTheme {
         ThreadContent(
             threadName = "Sample Thread",
-            uiState = uiState
+            uiState = uiState,
+            onRefresh = {}
         )
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -15,4 +15,8 @@ sealed class ThreadUiState {
     data class Success(
         val threadMessages: List<ThreadMessage>,
     ) : ThreadUiState()
+
+    data class Refreshing(
+        val threadMessages: List<ThreadMessage> = emptyList(),
+    ) : ThreadUiState()
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -27,26 +27,40 @@ class ThreadViewModel @AssistedInject constructor(
     val uiState: StateFlow<ThreadUiState> = _uiState.asStateFlow()
 
     init {
-        loadMessages()
+        initialMessages()
     }
 
-    private fun loadMessages() {
+    fun initialMessages() {
         viewModelScope.launch {
             _uiState.value = ThreadUiState.Loading
-            val result = repository.getMessagesForThread(threadId = threadId)
-
-            result
-                .onSuccess {
-                    _uiState.value =
-                        ThreadUiState.Success(
-                            threadMessages = it
-                        )
-                }.onFailure {
-                    _uiState.value =
-                        ThreadUiState.Error(
-                            messageId = R.string.thread_error
-                        )
-                }
+            loadMessages()
         }
+    }
+
+    fun refreshMessages() {
+        viewModelScope.launch {
+            val threadMessages = (_uiState.value as? ThreadUiState.Success)?.threadMessages ?: emptyList()
+            _uiState.value =
+                ThreadUiState.Refreshing(
+                    threadMessages = threadMessages
+                )
+            loadMessages()
+        }
+    }
+
+    private suspend fun loadMessages() {
+        val result = repository.getMessagesForThread(threadId = threadId)
+        result
+            .onSuccess {
+                _uiState.value =
+                    ThreadUiState.Success(
+                        threadMessages = it
+                    )
+            }.onFailure {
+                _uiState.value =
+                    ThreadUiState.Error(
+                        messageId = R.string.thread_error
+                    )
+            }
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -30,7 +30,7 @@ class ThreadViewModel @AssistedInject constructor(
         initialMessages()
     }
 
-    fun initialMessages() {
+    private fun initialMessages() {
         viewModelScope.launch {
             _uiState.value = ThreadUiState.Loading
             loadMessages()

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -36,20 +36,38 @@ class ThreadViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun createViewModel(): ThreadViewModel {
-        val repository = FakeSpaceRepository()
+    private fun createViewModel(getMessagesForThreadMock: (String) -> Result<List<ThreadMessage>>): ThreadViewModel {
+        val repository =
+            FakeSpaceRepository(
+                getMessagesForThreadMock = getMessagesForThreadMock
+            )
         return ThreadViewModel(threadId = "thread-1", repository = repository)
-    }
-
-    private fun failureCreateViewModel(): ThreadViewModel {
-        val repository = FakeSpaceRepository()
-        return ThreadViewModel(threadId = "failure-1", repository = repository)
     }
 
     @Test
     fun `メッセージ一覧が取得できる`() =
         runTest {
-            val viewModel = createViewModel()
+            val viewModel =
+                createViewModel(
+                    getMessagesForThreadMock = {
+                        success(
+                            listOf(
+                                ThreadMessage(
+                                    id = "msg-1",
+                                    body = "thread-1",
+                                    creator = Creator(name = "name1"),
+                                    comments = emptyList()
+                                ),
+                                ThreadMessage(
+                                    id = "msg-2",
+                                    body = "thread-2",
+                                    creator = Creator(name = "name2"),
+                                    comments = emptyList()
+                                )
+                            )
+                        )
+                    }
+                )
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
@@ -74,7 +92,12 @@ class ThreadViewModelTest {
     @Test
     fun `メッセージ一覧の取得に失敗`() =
         runTest {
-            val viewModel = failureCreateViewModel()
+            val viewModel =
+                createViewModel(
+                    getMessagesForThreadMock = {
+                        failure(IOException())
+                    }
+                )
 
             viewModel.uiState.test {
                 val initialState = awaitItem()
@@ -93,27 +116,62 @@ class ThreadViewModelTest {
     @Test
     fun `メッセージを一覧を更新できる`() =
         runTest {
-            val viewModel = createViewModel()
+            var callCount = 0
+            val viewModel =
+                createViewModel(getMessagesForThreadMock = {
+                    callCount++
+                    if (callCount == 1) {
+                        success(
+                            listOf(
+                                ThreadMessage(
+                                    id = "msg-1",
+                                    body = "thread-1",
+                                    creator = Creator(name = "name1"),
+                                    comments = emptyList()
+                                )
+                            )
+                        )
+                    } else {
+                        success(
+                            listOf(
+                                ThreadMessage(
+                                    id = "msg-1",
+                                    body = "thread-1",
+                                    creator = Creator(name = "name1"),
+                                    comments = emptyList()
+                                ),
+                                ThreadMessage(
+                                    id = "msg-2",
+                                    body = "thread-2",
+                                    creator = Creator(name = "name2"),
+                                    comments = emptyList()
+                                )
+                            )
+                        )
+                    }
+                })
 
             viewModel.uiState.test {
-                skipItems(3)
+                skipItems(2)
+
+                val loadedState = awaitItem()
+                loadedState.shouldBeInstanceOf<ThreadUiState.Success> {
+                    it.threadMessages.size shouldBe 1
+                }
                 viewModel.refreshMessages()
 
                 val loadingState = awaitItem()
                 loadingState shouldBe instanceOf<ThreadUiState.Refreshing>()
 
-                val loadedState = awaitItem()
-                loadedState.shouldBeInstanceOf<ThreadUiState.Success> {
-                    it.threadMessages.size shouldBe 3
+                val refreshedState = awaitItem()
+                refreshedState.shouldBeInstanceOf<ThreadUiState.Success> {
+                    it.threadMessages.size shouldBe 2
                     it.threadMessages[0].id shouldBe "msg-1"
                     it.threadMessages[0].body shouldBe "thread-1"
                     it.threadMessages[0].creator shouldBe Creator(name = "name1")
                     it.threadMessages[1].id shouldBe "msg-2"
                     it.threadMessages[1].body shouldBe "thread-2"
                     it.threadMessages[1].creator shouldBe Creator(name = "name2")
-                    it.threadMessages[2].id shouldBe "msg-3"
-                    it.threadMessages[2].body shouldBe "thread-3"
-                    it.threadMessages[2].creator shouldBe Creator(name = "name3")
                 }
             }
         }
@@ -121,7 +179,12 @@ class ThreadViewModelTest {
     @Test
     fun `メッセージ一覧の更新に失敗`() =
         runTest {
-            val viewModel = failureCreateViewModel()
+            val viewModel =
+                createViewModel(
+                    getMessagesForThreadMock = {
+                        failure(IOException())
+                    }
+                )
 
             viewModel.uiState.test {
                 skipItems(3)
@@ -138,56 +201,10 @@ class ThreadViewModelTest {
         }
 }
 
-private class FakeSpaceRepository : SpaceRepository {
-    var callCount = 0
-
+private class FakeSpaceRepository(
+    private val getMessagesForThreadMock: (String) -> Result<List<ThreadMessage>>,
+) : SpaceRepository {
     override suspend fun getAllThreads(spaceId: String): List<Thread> = emptyList()
 
-    override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> {
-        if (threadId == "thread-1") {
-            callCount++
-            if (callCount == 1) { // 2回目以降の呼び出しは1回目より件数を増やす
-                return success(
-                    listOf(
-                        ThreadMessage(
-                            id = "msg-1",
-                            body = "thread-1",
-                            creator = Creator(name = "name1"),
-                            comments = emptyList()
-                        ),
-                        ThreadMessage(
-                            id = "msg-2",
-                            body = "thread-2",
-                            creator = Creator(name = "name2"),
-                            comments = emptyList()
-                        )
-                    )
-                )
-            } else {
-                return success(
-                    listOf(
-                        ThreadMessage(
-                            id = "msg-1",
-                            body = "thread-1",
-                            creator = Creator(name = "name1"),
-                            comments = emptyList()
-                        ),
-                        ThreadMessage(
-                            id = "msg-2",
-                            body = "thread-2",
-                            creator = Creator(name = "name2"),
-                            comments = emptyList()
-                        ),
-                        ThreadMessage(
-                            id = "msg-3",
-                            body = "thread-3",
-                            creator = Creator(name = "name3"),
-                            comments = emptyList()
-                        )
-                    )
-                )
-            }
-        }
-        return failure(IOException())
-    }
+    override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> = getMessagesForThreadMock(threadId)
 }

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -89,29 +89,104 @@ class ThreadViewModelTest {
                 }
             }
         }
+
+    @Test
+    fun `メッセージを一覧を更新できる`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                skipItems(3)
+                viewModel.refreshMessages()
+
+                val loadingState = awaitItem()
+                loadingState shouldBe instanceOf<ThreadUiState.Refreshing>()
+
+                val loadedState = awaitItem()
+                loadedState.shouldBeInstanceOf<ThreadUiState.Success> {
+                    it.threadMessages.size shouldBe 3
+                    it.threadMessages[0].id shouldBe "msg-1"
+                    it.threadMessages[0].body shouldBe "thread-1"
+                    it.threadMessages[0].creator shouldBe Creator(name = "name1")
+                    it.threadMessages[1].id shouldBe "msg-2"
+                    it.threadMessages[1].body shouldBe "thread-2"
+                    it.threadMessages[1].creator shouldBe Creator(name = "name2")
+                    it.threadMessages[2].id shouldBe "msg-3"
+                    it.threadMessages[2].body shouldBe "thread-3"
+                    it.threadMessages[2].creator shouldBe Creator(name = "name3")
+                }
+            }
+        }
+
+    @Test
+    fun `メッセージ一覧の更新に失敗`() =
+        runTest {
+            val viewModel = failureCreateViewModel()
+
+            viewModel.uiState.test {
+                skipItems(3)
+                viewModel.refreshMessages()
+
+                val loadingState = awaitItem()
+                loadingState shouldBe instanceOf<ThreadUiState.Refreshing>()
+
+                val loadedState = awaitItem()
+                loadedState.shouldBeInstanceOf<ThreadUiState.Error> {
+                    it.messageId shouldBe R.string.thread_error
+                }
+            }
+        }
 }
 
 private class FakeSpaceRepository : SpaceRepository {
+    var callCount = 0
+
     override suspend fun getAllThreads(spaceId: String): List<Thread> = emptyList()
 
     override suspend fun getMessagesForThread(threadId: String): Result<List<ThreadMessage>> {
         if (threadId == "thread-1") {
-            return success(
-                listOf(
-                    ThreadMessage(
-                        id = "msg-1",
-                        body = "thread-1",
-                        creator = Creator(name = "name1"),
-                        comments = emptyList()
-                    ),
-                    ThreadMessage(
-                        id = "msg-2",
-                        body = "thread-2",
-                        creator = Creator(name = "name2"),
-                        comments = emptyList()
+            callCount++
+            if (callCount == 1) { // 2回目以降の呼び出しは1回目より件数を増やす
+                return success(
+                    listOf(
+                        ThreadMessage(
+                            id = "msg-1",
+                            body = "thread-1",
+                            creator = Creator(name = "name1"),
+                            comments = emptyList()
+                        ),
+                        ThreadMessage(
+                            id = "msg-2",
+                            body = "thread-2",
+                            creator = Creator(name = "name2"),
+                            comments = emptyList()
+                        )
                     )
                 )
-            )
+            } else {
+                return success(
+                    listOf(
+                        ThreadMessage(
+                            id = "msg-1",
+                            body = "thread-1",
+                            creator = Creator(name = "name1"),
+                            comments = emptyList()
+                        ),
+                        ThreadMessage(
+                            id = "msg-2",
+                            body = "thread-2",
+                            creator = Creator(name = "name2"),
+                            comments = emptyList()
+                        ),
+                        ThreadMessage(
+                            id = "msg-3",
+                            body = "thread-3",
+                            creator = Creator(name = "name3"),
+                            comments = emptyList()
+                        )
+                    )
+                )
+            }
         }
         return failure(IOException())
     }


### PR DESCRIPTION
pull to refreshでページの更新をする機能を追加しました。

更新中はpull to refreshのインジケータが表示される。
画面には前回の取得時に取得していた情報を表示し続ける。

UiStateに更新中を示すRefreshingを追加
初回ロード時と同じステータス（Loding)を利用した場合、画面中央のインジケータが表示されてしまう。更新時のインジケータと重複して表示されるため