### PR TITLE
feat:ThreadScreenにpull-to-refresh機能を実装

### DIFF
--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -27,6 +27,9 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
+import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -64,7 +67,8 @@ fun ThreadScreen(
     ThreadContent(
         threadName = threadName,
         uiState = uiState,
-        onErrorMessageShown = viewModel::errorMessageShown
+        onErrorMessageShown = viewModel::errorMessageShown,
+        onRefresh = viewModel::refresh
     )
 }
 
@@ -74,6 +78,7 @@ fun ThreadContent(
     threadName: String,
     uiState: ThreadUiState,
     onErrorMessageShown: () -> Unit,
+    onRefresh: () -> Unit = {},
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     Scaffold(
@@ -102,16 +107,21 @@ fun ThreadContent(
                 CircularProgressIndicator()
             }
         } else {
-            LazyColumn(
-                modifier =
-                    Modifier
-                        .fillMaxSize()
-                        .padding(innerPadding),
-                contentPadding = PaddingValues(all = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+            PullToRefreshBox(
+                isRefreshing = uiState.isRefreshing,
+                onRefresh = onRefresh,
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
             ) {
-                items(uiState.threadMessages) { threadMessage ->
-                    MessageListItem(threadMessage = threadMessage)
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(all = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(uiState.threadMessages) { threadMessage ->
+                        MessageListItem(threadMessage = threadMessage)
+                    }
                 }
             }
         }
@@ -245,7 +255,8 @@ fun ThreadContentPreview(
         ThreadContent(
             threadName = "Sample Thread",
             uiState = uiState,
-            onErrorMessageShown = {}
+            onErrorMessageShown = {},
+            onRefresh = {}
         )
     }
 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -28,8 +28,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
-import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
-import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -110,9 +108,10 @@ fun ThreadContent(
             PullToRefreshBox(
                 isRefreshing = uiState.isRefreshing,
                 onRefresh = onRefresh,
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(innerPadding)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
             ) {
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadUiState.kt
@@ -5,6 +5,7 @@ import com.cybozu.sample.kintone.spaces.data.space.entity.ThreadMessage
 data class ThreadUiState(
     val threadMessages: List<ThreadMessage> = emptyList(),
     val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
     val errorMessage: String? = null, // エラーメッセージを文字列で直接管理する。
     // Booleanで管理することも最初考慮したが、エラーにも「サーバーエラー」や「ネットワークエラー」
     // など様々なエラーが発生しうると考え、Stringでの管理を採用した。

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -47,16 +47,17 @@ class ThreadViewModel @AssistedInject constructor(
 
     private fun fetchMessages(isRefresh: Boolean) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(
-                isLoading = !isRefresh,
-                isRefreshing = isRefresh
-            )
-            
+            _uiState.value =
+                _uiState.value.copy(
+                    isLoading = !isRefresh,
+                    isRefreshing = isRefresh
+                )
+
             // Pull to Refreshの挙動確認用の遅延（開発用）
             if (isRefresh) {
                 delay(1500)
             }
-            
+
             repository
                 .getMessagesForThread(threadId = threadId)
                 .onSuccess { threadMessages ->

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -10,6 +10,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -36,22 +37,41 @@ class ThreadViewModel @AssistedInject constructor(
         _uiState.value = _uiState.value.copy(errorMessage = null)
     }
 
+    fun refresh() {
+        fetchMessages(isRefresh = true)
+    }
+
     private fun loadMessages() {
+        fetchMessages(isRefresh = false)
+    }
+
+    private fun fetchMessages(isRefresh: Boolean) {
         viewModelScope.launch {
-            _uiState.value = _uiState.value.copy(isLoading = true)
+            _uiState.value = _uiState.value.copy(
+                isLoading = !isRefresh,
+                isRefreshing = isRefresh
+            )
+            
+            // Pull to Refreshの挙動確認用の遅延（開発用）
+            if (isRefresh) {
+                delay(1500)
+            }
+            
             repository
                 .getMessagesForThread(threadId = threadId)
                 .onSuccess { threadMessages ->
                     _uiState.value =
                         _uiState.value.copy(
                             threadMessages = threadMessages,
-                            isLoading = false
+                            isLoading = false,
+                            isRefreshing = false
                         )
                 }.onFailure {
                     // 'it' is the Throwable (error) here
                     _uiState.value =
                         _uiState.value.copy(
                             isLoading = false,
+                            isRefreshing = false,
                             errorMessage = "メッセージを取得できませんでした\n原因: ${getLocalizedErrorMessage(it)}"
                         )
                 }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModel.kt
@@ -10,7 +10,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import java.io.IOException
 import java.net.SocketTimeoutException
 import java.net.UnknownHostException
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -52,11 +51,6 @@ class ThreadViewModel @AssistedInject constructor(
                     isLoading = !isRefresh,
                     isRefreshing = isRefresh
                 )
-
-            // Pull to Refreshの挙動確認用の遅延（開発用）
-            if (isRefresh) {
-                delay(1500)
-            }
 
             repository
                 .getMessagesForThread(threadId = threadId)

--- a/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
+++ b/feature/communicate/src/test/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadViewModelTest.kt
@@ -85,6 +85,65 @@ class ThreadViewModelTest {
                 errorState.errorMessage shouldBe "メッセージを取得できませんでした\n原因: 不明なエラー"
             }
         }
+
+    @Test
+    fun `リフレッシュが成功する`() =
+        runTest {
+            val viewModel = createViewModel()
+
+            viewModel.uiState.test {
+                // まず最初のロードが完了するまで待つ
+                awaitItem() // 初期状態（まだ何もない）
+                awaitItem() // ローディング中の状態
+                val loadedState = awaitItem() // ロード完了しデータが入った状態
+                loadedState.threadMessages.size shouldBe 2
+                loadedState.isLoading shouldBe false
+                loadedState.isRefreshing shouldBe false
+
+                // ここでリフレッシュを実行
+                viewModel.refresh()
+
+                // リフレッシュ中の状態をチェック
+                val refreshingState = awaitItem()
+                refreshingState.threadMessages.size shouldBe 2 // 前のデータはそのまま表示されてるはず
+                refreshingState.isLoading shouldBe false // 初回ロードじゃないのでfalse
+                refreshingState.isRefreshing shouldBe true // リフレッシュ中フラグがtrue
+
+                // リフレッシュが完了した状態をcheck
+                val refreshedState = awaitItem()
+                refreshedState.threadMessages.size shouldBe 2
+                refreshedState.isLoading shouldBe false
+                refreshedState.isRefreshing shouldBe false // リフレッシュ完了でfalseに戻る
+                refreshedState.errorMessage shouldBe null
+            }
+        }
+
+    @Test
+    fun `リフレッシュが失敗したときもちゃんとエラーメッセージが表示される`() =
+        runTest {
+            val viewModel = createViewModel(shouldFail = true)
+
+            viewModel.uiState.test {
+                // 最初のロードが失敗するパターンで進める
+                awaitItem() // 初期状態
+                awaitItem() // ローディング状態
+                awaitItem() // エラー状態（初回ロード失敗）
+
+                // 失敗する想定だが、リフレッシュを実行してみる
+                viewModel.refresh()
+
+                // リフレッシュ中の状態を確認（エラーでもリフレッシュはできる）
+                val refreshingState = awaitItem()
+                refreshingState.isLoading shouldBe false
+                refreshingState.isRefreshing shouldBe true // リフレッシュ実行中
+
+                // リフレッシュも失敗した状態をcheckす
+                val errorState = awaitItem()
+                errorState.isLoading shouldBe false
+                errorState.isRefreshing shouldBe false // リフレッシュ終了
+                errorState.errorMessage shouldBe "メッセージを取得できませんでした\n原因: 不明なエラー"
+            }
+        }
 }
 
 private class FakeSpaceRepository(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.12.0"
+agp = "8.11.1"
 hiltNavigationCompose = "1.2.0"
 kotestAssertionsCore = "5.9.1"
 kotlin = "2.2.0"


### PR DESCRIPTION
ThreadScreenにpull-to-refresh機能を実装しました。

  Material3のPullToRefreshBoxコンポーネントを使用して、ユーザーがスワイプダウンすることでメッセージ
  一覧を更新できるようになります。

  実装内容：

 ①ThreadUiStateにisRefreshingフィールドを追加し、リフレッシュ中の状態を管理
 
 理由...初回ロード時と同じステータス（Loading）を利用した実装の場合、画面中央のインジケーターが表示されてしま
  い、pull-to-refreshのインジケーターと重複してしまったっぽい？ので、途中で分離する実装に変更する工夫をしました。

②ThreadViewModelにrefresh()メソッドを追加し、既存のエラーハンドリング機構を活用


  ## テストしたこと
  - [x] エミュレーターで実際にpull-to-refreshの動作を確認
  - [x] ブラウザの開発環境からメッセージを投稿し、正常に更新されることを確認
  - [x] リフレッシュ中はインジケーターが適切に表示されることを確認
  - [x] ネットワークエラー時にもエラーメッセージが表示されることを確認
  - [x] 既存の機能（初回ロード、エラー表示等）に影響がないことを確認
  - [x] ThreadViewModelのユニットテストを追加し、リフレッシュ機能の動作を検証した。
  - [x] 全てのテストが正常にパスすることを確認。
  - [x] lint checkが通ることを確認。


　##工夫したこと

①に書いてありますが、状態をisloadingとisRefreshingに分離した。

レビュワーが見やすいように自分なりにプルリクの説明をわかりやすいようにした。
　
