### PR TITLE
ナビゲーションの実装を androidx.navigation3 を使用するようにリファクタリング

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -37,7 +37,9 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.navigation3.runtime)
+    implementation(libs.androidx.navigation3.ui)
+    implementation(libs.androidx.lifecycle.viewmodel.navigation3)
 
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)

--- a/app/src/main/java/com/cybozu/sample/kintone/spaces/MainActivity.kt
+++ b/app/src/main/java/com/cybozu/sample/kintone/spaces/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
 import androidx.navigation3.ui.NavDisplay
 import com.cybozu.sample.kintone.spaces.core.design.theme.KintoneSpacesTheme
 import com.cybozu.sample.kintone.spaces.feature.communicate.SpaceRoute
+import com.cybozu.sample.kintone.spaces.feature.communicate.ThreadRoute
 import com.cybozu.sample.kintone.spaces.feature.communicate.communicateNavigation
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -43,7 +44,11 @@ fun KintoneSpacesApp() {
             ),
         entryProvider =
             entryProvider {
-                communicateNavigation(backStack)
+                communicateNavigation(
+                    onThreadClick = { threadId, threadName ->
+                        backStack.add(ThreadRoute(threadId = threadId, threadName = threadName))
+                    }
+                )
             }
     )
 }

--- a/app/src/main/java/com/cybozu/sample/kintone/spaces/MainActivity.kt
+++ b/app/src/main/java/com/cybozu/sample/kintone/spaces/MainActivity.kt
@@ -5,8 +5,11 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
+import androidx.navigation3.runtime.entryProvider
+import androidx.navigation3.runtime.rememberNavBackStack
+import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
+import androidx.navigation3.ui.NavDisplay
 import com.cybozu.sample.kintone.spaces.core.design.theme.KintoneSpacesTheme
 import com.cybozu.sample.kintone.spaces.feature.communicate.SpaceRoute
 import com.cybozu.sample.kintone.spaces.feature.communicate.communicateNavigation
@@ -27,11 +30,20 @@ class MainActivity : ComponentActivity() {
 
 @Composable
 fun KintoneSpacesApp() {
-    val navController = rememberNavController()
-    NavHost(
-        navController = navController,
-        startDestination = SpaceRoute
-    ) {
-        communicateNavigation(navController)
-    }
+    val backStack = rememberNavBackStack(SpaceRoute)
+    NavDisplay(
+        backStack = backStack,
+        onBack = { backStack.removeLastOrNull() },
+        // ViewModelStoreNavEntryDecorator を追加するため、デフォルトの
+        // NavEntryDecorator も明示的に指定する必要がある
+        entryDecorators =
+            listOf(
+                rememberSaveableStateHolderNavEntryDecorator(),
+                rememberViewModelStoreNavEntryDecorator()
+            ),
+        entryProvider =
+            entryProvider {
+                communicateNavigation(backStack)
+            }
+    )
 }

--- a/feature/communicate/build.gradle.kts
+++ b/feature/communicate/build.gradle.kts
@@ -23,11 +23,11 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
-    implementation(libs.androidx.navigation.compose)
+    implementation(libs.androidx.navigation3.runtime)
     implementation(libs.androidx.material.icons.extended)
     implementation(libs.androidx.lifecycle.viewmodel.ktx)
     implementation(libs.hilt.android)
-    implementation(libs.androidx.hilt.navigation.compose)
+    implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
@@ -1,23 +1,20 @@
 package com.cybozu.sample.kintone.spaces.feature.communicate
 
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
-import androidx.navigation.compose.composable
-import androidx.navigation.toRoute
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
 import com.cybozu.sample.kintone.spaces.feature.communicate.space.SpaceScreen
 import com.cybozu.sample.kintone.spaces.feature.communicate.thread.ThreadScreen
 
-fun NavGraphBuilder.communicateNavigation(navController: NavController) {
-    composable<SpaceRoute> {
+fun EntryProviderScope<NavKey>.communicateNavigation(backStack: MutableList<NavKey>) {
+    entry<SpaceRoute> {
         SpaceScreen(
             onThreadClick = { thread ->
-                navController.navigate(ThreadRoute(threadId = thread.id, threadName = thread.name))
+                backStack.add(ThreadRoute(threadId = thread.id, threadName = thread.name))
             }
         )
     }
 
-    composable<ThreadRoute> { backStackEntry ->
-        val threadRoute = backStackEntry.toRoute<ThreadRoute>()
+    entry<ThreadRoute> { threadRoute ->
         ThreadScreen(
             threadId = threadRoute.threadId,
             threadName = threadRoute.threadName

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
@@ -5,11 +5,13 @@ import androidx.navigation3.runtime.NavKey
 import com.cybozu.sample.kintone.spaces.feature.communicate.space.SpaceScreen
 import com.cybozu.sample.kintone.spaces.feature.communicate.thread.ThreadScreen
 
-fun EntryProviderScope<NavKey>.communicateNavigation(backStack: MutableList<NavKey>) {
+fun EntryProviderScope<NavKey>.communicateNavigation(
+    onThreadClick: (threadId: String, threadName: String) -> Unit,
+) {
     entry<SpaceRoute> {
         SpaceScreen(
             onThreadClick = { thread ->
-                backStack.add(ThreadRoute(threadId = thread.id, threadName = thread.name))
+                onThreadClick(thread.id, thread.name)
             }
         )
     }

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateNavigation.kt
@@ -5,9 +5,7 @@ import androidx.navigation3.runtime.NavKey
 import com.cybozu.sample.kintone.spaces.feature.communicate.space.SpaceScreen
 import com.cybozu.sample.kintone.spaces.feature.communicate.thread.ThreadScreen
 
-fun EntryProviderScope<NavKey>.communicateNavigation(
-    onThreadClick: (threadId: String, threadName: String) -> Unit,
-) {
+fun EntryProviderScope<NavKey>.communicateNavigation(onThreadClick: (threadId: String, threadName: String) -> Unit) {
     entry<SpaceRoute> {
         SpaceScreen(
             onThreadClick = { thread ->

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateRoute.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/CommunicateRoute.kt
@@ -1,12 +1,13 @@
 package com.cybozu.sample.kintone.spaces.feature.communicate
 
+import androidx.navigation3.runtime.NavKey
 import kotlinx.serialization.Serializable
 
 @Serializable
-object SpaceRoute
+data object SpaceRoute : NavKey
 
 @Serializable
 data class ThreadRoute(
     val threadId: String,
     val threadName: String,
-)
+) : NavKey

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/space/SpaceScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.cybozu.sample.kintone.spaces.core.design.component.Html
 import com.cybozu.sample.kintone.spaces.core.design.theme.KintoneSpacesTheme
 import com.cybozu.sample.kintone.spaces.data.space.entity.Thread

--- a/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
+++ b/feature/communicate/src/main/java/com/cybozu/sample/kintone/spaces/feature/communicate/thread/ThreadScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.cybozu.sample.kintone.spaces.core.design.component.Html
 import com.cybozu.sample.kintone.spaces.core.design.component.SystemBackNavButton
 import com.cybozu.sample.kintone.spaces.core.design.theme.KintoneSpacesTheme

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 agp = "8.11.1"
-hiltNavigationCompose = "1.2.0"
+hiltLifecycleViewmodelCompose = "1.3.0"
 kotestAssertionsCore = "5.9.1"
 kotlin = "2.2.0"
 coreKtx = "1.16.0"
 junit = "4.13.2"
 kotlinxCoroutinesTest = "1.10.2"
-lifecycleVersion = "2.9.2"
+lifecycleVersion = "2.10.0"
 activityCompose = "1.10.1"
 composeBom = "2025.07.00"
-navigationCompose = "2.9.3"
+navigation3 = "1.1.4"
 hilt = "2.57"
 turbine = "1.2.1"
 ktlint-gradle = "13.0.0"
@@ -19,8 +19,9 @@ okhttp = "4.12.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
-androidx-hilt-navigation-compose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
+androidx-hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "hiltLifecycleViewmodelCompose" }
 androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleVersion" }
+androidx-lifecycle-viewmodel-navigation3 = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-navigation3", version.ref = "lifecycleVersion" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "activityCompose" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "composeBom" }
 androidx-ui = { group = "androidx.compose.ui", name = "ui" }
@@ -29,7 +30,8 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
-androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation3-runtime = { group = "androidx.navigation3", name = "navigation3-runtime", version.ref = "navigation3" }
+androidx-navigation3-ui = { group = "androidx.navigation3", name = "navigation3-ui", version.ref = "navigation3" }
 hilt-android = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
 hilt-compiler = { group = "com.google.dagger", name = "hilt-compiler", version.ref = "hilt" }
 androidx-material-icons-extended = { group = "androidx.compose.material", name = "material-icons-extended" }


### PR DESCRIPTION
- 2026年育成型のissueとしてはNavigation3を前提に画面追加や遷移の実装をしてもらうことになったためベースをNavigation3に置き換えた